### PR TITLE
Detected code that calls async_forward_entry_setup for integration

### DIFF
--- a/custom_components/lkcomu_interrao/__init__.py
+++ b/custom_components/lkcomu_interrao/__init__.py
@@ -338,13 +338,10 @@ async def async_setup_entry(
     hass.data.setdefault(DATA_UPDATE_DELEGATORS, {})[entry_id] = {}
 
     # Forward entry setup to sensor platform
-    for domain in (SENSOR_DOMAIN, BINARY_SENSOR_DOMAIN):
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(
-                config_entry,
-                domain,
-            )
-        )
+    await hass.config_entries.async_forward_entry_setups(
+        config_entry,
+        [SENSOR_DOMAIN, BINARY_SENSOR_DOMAIN],
+    )
 
     # Create options update listener
     update_listener = config_entry.add_update_listener(async_reload_entry)

--- a/custom_components/lkcomu_interrao/_base.py
+++ b/custom_components/lkcomu_interrao/_base.py
@@ -44,7 +44,8 @@ from homeassistant.const import (
 from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_track_time_interval
-from homeassistant.helpers.typing import ConfigType, HomeAssistantType
+from homeassistant.helpers.typing import ConfigType
+from homeassistant.core import HomeAssistant
 from homeassistant.util import as_local, utcnow
 
 from custom_components.lkcomu_interrao._util import (
@@ -92,7 +93,7 @@ def make_common_async_setup_entry(
     entity_cls: Type["LkcomuInterRAOEntity"], *args: Type["LkcomuInterRAOEntity"]
 ):
     async def _async_setup_entry(
-        hass: HomeAssistantType,
+        hass: HomeAssistant,
         config_entry: ConfigEntry,
         async_add_devices,
     ):
@@ -126,7 +127,7 @@ def make_common_async_setup_entry(
 
 
 async def async_register_update_delegator(
-    hass: HomeAssistantType,
+    hass: HomeAssistant,
     config_entry: ConfigEntry,
     platform: str,
     async_add_entities: AddEntitiesCallType,
@@ -146,7 +147,7 @@ async def async_register_update_delegator(
         await async_refresh_api_data(hass, config_entry)
 
 
-async def async_refresh_api_data(hass: HomeAssistantType, config_entry: ConfigEntry):
+async def async_refresh_api_data(hass: HomeAssistant, config_entry: ConfigEntry):
     entry_id = config_entry.entry_id
     api: "BaseEnergosbytAPI" = hass.data[DATA_API_OBJECTS][entry_id]
 

--- a/custom_components/lkcomu_interrao/_util.py
+++ b/custom_components/lkcomu_interrao/_util.py
@@ -20,7 +20,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_TYPE, CONF_USERNAME
 from homeassistant.core import callback
 from homeassistant.helpers.entity_platform import EntityPlatform
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.core import HomeAssistant
 
 from custom_components.lkcomu_interrao.const import DOMAIN
 from inter_rao_energosbyt.enums import ProviderType
@@ -49,7 +49,7 @@ def _make_log_prefix(
 
 @callback
 def _find_existing_entry(
-    hass: HomeAssistantType, type_: str, username: str
+    hass: HomeAssistant, type_: str, username: str
 ) -> Optional[config_entries.ConfigEntry]:
     existing_entries = hass.config_entries.async_entries(DOMAIN)
     for config_entry in existing_entries:

--- a/custom_components/lkcomu_interrao/sensor.py
+++ b/custom_components/lkcomu_interrao/sensor.py
@@ -24,11 +24,11 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     CONF_DESCRIPTION,
-    STATE_LOCKED,
     STATE_OK,
     STATE_PROBLEM,
     STATE_UNKNOWN,
 )
+from homeassistant.components.lock.const import LockState
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.util import slugify
@@ -265,7 +265,7 @@ class LkcomuAccount(LkcomuInterRAOEntity[Account], SensorEntity):
         }
 
         if account.is_locked:
-            attributes[ATTR_STATUS] = STATE_LOCKED
+            attributes[ATTR_STATUS] = LockState.LOCKED
             attributes[ATTR_REASON] = account.lock_reason
 
         else:


### PR DESCRIPTION
Detected code that calls async_forward_entry_setup for integration lkcomu_interrao with title: my.mosenergosbyt.ru (**********@mail.ru) and entry_id: c5e37740**************f67b2af61c, during setup without awaiting async_forward_entry_setup, which can cause the setup lock to be released before the setup is done. This will stop working in Home Assistant 2025.1. Please report this issue.